### PR TITLE
Update lab2.md: add stdbool.h to utils.h

### DIFF
--- a/labbar/lab2.md
+++ b/labbar/lab2.md
@@ -430,6 +430,7 @@ funktionsprototyper från `utils.c`. I `utils.h` borde det nu alltså
 åtminstone stå:
 
 ```c
+#include <stdbool.h>
 int read_string(char *buf, int buf_siz);
 bool is_number(char *str);
 int ask_question_int(char *question);


### PR DESCRIPTION
Reaction to this post: https://piazza.com/class/j6rwkke0tw922y?cid=9

I'm making this a PR consciously (rather than just merging) as this is not clearly a bug, but a stylistic issue. Merging it would be pragmatic, as it saves the students problems though, is my guess.

If it's not merged we should say that `stdbool.h` must be included in their own code.